### PR TITLE
emty initialization of inline cache

### DIFF
--- a/jit.js
+++ b/jit.js
@@ -874,8 +874,9 @@ to single-step.
 
         this.source.push("vm.pc = ", this.pc, ";");
 
+        var ic;
         if (this.method.ic)
-            var ic = this.method.ic[this.pc];
+            ic = this.method.ic[this.pc];
 
         if(ic && ic.primIndex > 0) {
             this.source.push("var sendDone = false;");

--- a/jit.js
+++ b/jit.js
@@ -478,13 +478,13 @@ to single-step.
                     break;
                 // send literal selector
                 case 0xD0: case 0xD8:
-                    this.generateSend("lit[", 1 + (byte & 0x0F), "]", 0, false, this.method.ic[this.pc]);
+                    this.generateSend("lit[", 1 + (byte & 0x0F), "]", 0, false);
                     break;
                 case 0xE0: case 0xE8:
-                    this.generateSend("lit[", 1 + (byte & 0x0F), "]", 1, false, this.method.ic[this.pc]);
+                    this.generateSend("lit[", 1 + (byte & 0x0F), "]", 1, false);
                     break;
                 case 0xF0: case 0xF8:
-                    this.generateSend("lit[", 1 + (byte & 0x0F), "]", 2, false, this.method.ic[this.pc]);
+                    this.generateSend("lit[", 1 + (byte & 0x0F), "]", 2, false);
                     break;
             }
         }
@@ -868,13 +868,16 @@ to single-step.
 
         this.source.push("}");
     },
-    generateSend: function(prefix, num, suffix, numArgs, superSend, ic) {
+    generateSend: function(prefix, num, suffix, numArgs, superSend) {
         if (this.debug) this.generateDebugCode("send " + (prefix === "lit[" ? this.method.pointers[num].bytesAsString() : "..."));
         this.generateLabel();
 
         this.source.push("vm.pc = ", this.pc, ";");
 
-        if (ic && ic.primIndex > 0) {
+        if (this.method.ic)
+            var ic = this.method.ic[this.pc];
+
+        if(ic && ic.primIndex > 0) {
             this.source.push("var sendDone = false;");
             this.generatePrimitiveSend(ic, prefix, num, suffix, numArgs, superSend);
             this.source.push(

--- a/vm.js
+++ b/vm.js
@@ -1365,7 +1365,7 @@ Object.subclass('Squeak.Object',
         } else { // Bytes
             if (this.format >= 12) {
                 this.compiled = false;
-                this.ic = new Array();
+                this.ic = null;
             }
             if (indexableSize > 0) {
                 // this.format |= -indexableSize & 3;       //deferred to writeTo()
@@ -1435,7 +1435,7 @@ Object.subclass('Squeak.Object',
             this.pointers = this.decodePointers(numLits+1, oops, oopMap); //header+lits
             this.bytes = this.decodeBytes(nWords-(numLits+1), this.bits, numLits+1, this.format & 3);
             this.compiled = false;
-            this.ic = new Array(this.bytes.byteLength);
+            this.ic = null;
         } else if (this.format >= 8) {
             //Formats 8..11 -- ByteArrays (and ByteStrings)
             if (nWords > 0)
@@ -2362,6 +2362,9 @@ Object.subclass('Squeak.Interpreter',
 'sending', {
     send: function(selector, argCount, doSuper) {
         var newRcvr = this.stackValue(argCount);
+
+        if(!this.method.ic)
+            this.method.ic = new Array(this.method.bytes.byteLength);
 
         var ic = this.method.ic[this.pc];
         var entry;


### PR DESCRIPTION
solves #9 

Reduced memory consumption of Squeak4.5-13680.image after startup from 418/419 mb down to 410mb. I only have those three samples as the heap dump takes a while, but the memory consumption should be quite constant, i guess.

Primitive inlining didn't happen for extended sends so far. Now it does.
